### PR TITLE
fix: display negative scale weights instead of NaN

### DIFF
--- a/Firmware/RoboTricklerUI/RoboTricklerUI.ino
+++ b/Firmware/RoboTricklerUI/RoboTricklerUI.ino
@@ -152,7 +152,7 @@ unsigned long wifiInterval = 10000;
 const float WEIGHT_STEP_SIZES[] = {0.001, 0.01, 0.1, 1.0, 10.0};
 const byte WEIGHT_STEP_COUNT = sizeof(WEIGHT_STEP_SIZES) / sizeof(WEIGHT_STEP_SIZES[0]);
 
-float weight = -1.0;
+float weight = NAN;
 int decPlaces = DEC_PLACES;
 String unit = "";
 float lastWeight = 0;

--- a/Firmware/RoboTricklerUI/display_helpers.ino
+++ b/Firmware/RoboTricklerUI/display_helpers.ino
@@ -234,7 +234,7 @@ void updateTargetWeightLabel()
 void setWeightLabel(lv_obj_t *label)
 {
   char text[32];
-  if (!isfinite(weight) || (weight < 0.0f))
+  if (!isfinite(weight))
   {
     setLabelText(label, "NaN...");
     return;

--- a/Firmware/RoboTricklerUI/rs232.ino
+++ b/Firmware/RoboTricklerUI/rs232.ino
@@ -484,7 +484,7 @@ void readWeight()
     {
       updateDisplayLog(langText("status_timeout"), true);
     }
-    weight = -1.0;
+    weight = NAN;
     newData = false;
   }
   else


### PR DESCRIPTION
Sometime between 2.10 and 2.13 my trickler stopped showing values, when the scale went negative (e.g. when taking the weighing cup off, while being tared etc.).

Negative scale values are a perfectly normal thing and should not show up as "NaN", which is normally indicative of an error. Looking at the code, the code somewhere started using "-1.0" as the sentinel value for failed readings which isn't a robust solution, as this a) has to compare a float for equality, which in the case of -1.0 actually works, but is just bad style and b) there is NaN (Not a Number) for those cases.

This switches the "no reading sentinel" to NaN and in turn makes the trickler display negative scale values again, as it has in the past.

What was the reasoning behind making negative values "illegal"?